### PR TITLE
Change Badge on README for travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/wtheisen/commandChan.svg?branch=master)](https://travis-ci.com/wtheisen/commandChan)
+[![Build Status](https://api.travis-ci.com/wtheisen/TerminusBrowse.svg?branch=master)](https://travis-ci.com/wtheisen/commandChan)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 # TerminusBrowse - a terminal 4chan/Reddit browser


### PR DESCRIPTION
# Description

Updated badge to match the new repo url

This is what it should look like now (follow link)!
https://api.travis-ci.com/wtheisen/TerminusBrowse.svg?branch=master